### PR TITLE
add null check to gmail_query (#80)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Bundle a application token and secret in gmailr so the average user won't need to create an application.
 * Great number of bug fixes
 * Reworking the print functions to provide more useful and easy to read output
+* Added check for null response to fix bug with DELETE requests (#79) @josibake
 
 # gmailr 0.5.0
 

--- a/R/gmailr.R
+++ b/R/gmailr.R
@@ -339,7 +339,7 @@ gmailr_query <- function(fun, location, user_id, class = NULL, upload = FALSE,
     stop(cond)
   }
 
-  if (!is.null(class)) {
+  if (!is.null(class) && !is.null(result)) {
     class(result) <- class
   }
   result


### PR DESCRIPTION
* add null check to gmail_query

check for null value in result. this keeps gmailr_DELETE from failing. closes #79

* use && vs &

per the R docs: The longer form is appropriate for programming control-flow and typically preferred in if clauses.

* update news

add note for minor bug fix